### PR TITLE
Custom background color for negative zoom and drag gestures out of bounds + readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Zoomable
 
-A SwiftUI view modifier that provides pinch to zoom, double tap to zoom, and drag to pan functionalities.
+A SwiftUI view modifier that provides pinch to zoom, double tap to zoom, and drag to pan functionalities for iOS ad iPadOS apps.
 
+Supports Image and any kind of View, including `UIViewControllerRepresentable` and `UIViewRepresentable`.
 
 
 https://github.com/ryohey/Zoomable/assets/5355966/d88a9290-ee1d-4dd9-ac2c-b1e68548d256
@@ -29,12 +30,22 @@ https://github.com/ryohey/Zoomable.git
 To use the `Zoomable` modifier in your SwiftUI view:
 
 ```swift
-import YourLibraryName
+import Zoomable
 
 struct ContentView: View {
     var body: some View {
         Image("your-image-name")
             .zoomable()
+
+        /*
+        or
+        SomeView()
+            .zoomable(
+                minZoomScale: 0.5,        // Default value: 1
+                doubleTapZoomScale: 2,    // Default value: 3
+                outOfBoundsColor: .black  // Default value: .clear
+            )
+        */
     }
 }
 ```

--- a/Sources/Zoomable/Zoomable.swift
+++ b/Sources/Zoomable/Zoomable.swift
@@ -38,11 +38,8 @@ struct ZoomableModifier: ViewModifier {
                         }
                     }
                     .gesture(doubleTapGesture)
-                
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .edgesIgnoringSafeArea(.all)
     }
 
     @available(iOS, introduced: 16.0, deprecated: 17.0)

--- a/Sources/Zoomable/Zoomable.swift
+++ b/Sources/Zoomable/Zoomable.swift
@@ -5,41 +5,31 @@ import SwiftUI
 struct ZoomableModifier: ViewModifier {
     let minZoomScale: CGFloat
     let doubleTapZoomScale: CGFloat
-    let outOfBoundsColor: Color
 
     @State private var lastTransform: CGAffineTransform = .identity
     @State private var transform: CGAffineTransform = .identity
     @State private var contentSize: CGSize = .zero
 
     func body(content: Content) -> some View {
-        
-        GeometryReader { proxy in
-            
-            ZStack {
-                
-                outOfBoundsColor
-                
-                content
-                    .background(alignment: .topLeading) {
-                        GeometryReader { proxy in
-                            Color.clear
-                                .onAppear {
-                                    contentSize = proxy.size
-                                }
+        content
+            .background(alignment: .topLeading) {
+                GeometryReader { proxy in
+                    Color.clear
+                        .onAppear {
+                            contentSize = proxy.size
                         }
-                    }
-                    .animatableTransformEffect(transform)
-                    .gesture(dragGesture, including: transform == .identity ? .none : .all)
-                    .modify { view in
-                        if #available(iOS 17.0, *) {
-                            view.gesture(magnificationGesture)
-                        } else {
-                            view.gesture(oldMagnificationGesture)
-                        }
-                    }
-                    .gesture(doubleTapGesture)
+                }
             }
-        }
+            .animatableTransformEffect(transform)
+            .gesture(dragGesture, including: transform == .identity ? .none : .all)
+            .modify { view in
+                if #available(iOS 17.0, *) {
+                    view.gesture(magnificationGesture)
+                } else {
+                    view.gesture(oldMagnificationGesture)
+                }
+            }
+            .gesture(doubleTapGesture)
     }
 
     @available(iOS, introduced: 16.0, deprecated: 17.0)
@@ -148,14 +138,29 @@ public extension View {
     @ViewBuilder
     func zoomable(
         minZoomScale: CGFloat = 1,
-        doubleTapZoomScale: CGFloat = 3,
-        outOfBoundsColor: Color = .clear
+        doubleTapZoomScale: CGFloat = 3
     ) -> some View {
         modifier(ZoomableModifier(
             minZoomScale: minZoomScale,
-            doubleTapZoomScale: doubleTapZoomScale,
-            outOfBoundsColor: outOfBoundsColor
+            doubleTapZoomScale: doubleTapZoomScale
         ))
+    }
+
+    @ViewBuilder
+    func zoomable(
+        minZoomScale: CGFloat = 1,
+        doubleTapZoomScale: CGFloat = 3,
+        outOfBoundsColor: Color = .clear
+    ) -> some View {
+        GeometryReader { proxy in
+            ZStack {
+                outOfBoundsColor
+                self.zoomable(
+                    minZoomScale: minZoomScale,
+                    doubleTapZoomScale: doubleTapZoomScale
+                )
+            }
+        }
     }
 }
 

--- a/Sources/Zoomable/Zoomable.swift
+++ b/Sources/Zoomable/Zoomable.swift
@@ -9,7 +9,7 @@ struct ZoomableModifier: ViewModifier {
 
     @State private var lastTransform: CGAffineTransform = .identity
     @State private var transform: CGAffineTransform = .identity
-    @State private var imageSize: CGSize = .zero
+    @State private var contentSize: CGSize = .zero
 
     func body(content: Content) -> some View {
         
@@ -24,7 +24,7 @@ struct ZoomableModifier: ViewModifier {
                         GeometryReader { proxy in
                             Color.clear
                                 .onAppear {
-                                    imageSize = proxy.size
+                                    contentSize = proxy.size
                                 }
                         }
                     }
@@ -64,7 +64,7 @@ struct ZoomableModifier: ViewModifier {
             .onChanged { value in
                 let newTransform = CGAffineTransform.anchoredScale(
                     scale: value.magnification,
-                    anchor: value.startAnchor.scaledBy(imageSize)
+                    anchor: value.startAnchor.scaledBy(contentSize)
                 )
 
                 withAnimation(.interactiveSpring) {
@@ -127,8 +127,8 @@ struct ZoomableModifier: ViewModifier {
             return .identity
         }
 
-        let maxX = imageSize.width * (scaleX - 1)
-        let maxY = imageSize.height * (scaleY - 1)
+        let maxX = contentSize.width * (scaleX - 1)
+        let maxY = contentSize.height * (scaleY - 1)
 
         if transform.tx > 0
             || transform.tx < -maxX


### PR DESCRIPTION
Hi!

Yours is by far the cleanest implementation online, thank you!

I've taken the liberty to add an optional outOfBoundsColor parameter to allow customisation of the "background" color when the View is zoomed with negative scale or id dragged out of bounds.

This is achieved by wrapping the content in a ZStack with infinite frame and no safe area edges.

I've also updated the readme both to provide an example of this addition and to specify supported platforms and that not only Views of type Image are supported.

Hope everything is okay and that this is an addition you're interested for your project.